### PR TITLE
feat: remove unreliable CLI system installation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A Visual Studio Code extension that provides seamless integration with Costa AI 
 - **Automated Setup**: One-click setup for Claude Code and Codex integration
 - **Costa CLI Integration**: Bundled Costa CLI for macOS, Windows, and Linux with automatic platform detection
 - **Usage Dashboard**: Dedicated sidebar panels for detailed usage information and setup management
-- **System Installation**: Install Costa CLI to `/usr/local/bin` for system-wide access (macOS/Linux)
 
 ## Configurations
 
@@ -33,7 +32,6 @@ This extension currently has no user-configurable settings. All configuration is
 | `costa.refresh`           | Costa Code: Refresh                     |
 | `costa.showExtensionInfo` | Costa Code: Show Extension Info         |
 | `costa.refreshPoints`     | Costa Code: Refresh Points              |
-| `costa.install.system`    | Costa Code: Install Costa CLI to System |
 
 <!-- commands -->
 
@@ -61,7 +59,6 @@ The extension provides two webview panels in the Costa activity bar:
 ### Setup Panel
 - **Claude Code Setup**: Configure Claude Code to use Costa AI models
 - **Codex Setup**: Configure Codex integration
-- **Costa CLI Installation**: Install the bundled CLI to your system path (macOS/Linux)
 - Status indicators showing configuration state for each component
 - One-click setup buttons for each integration
 
@@ -136,6 +133,5 @@ To install an internal build of the Costa VS Code extension for use inside Costa
 
 ## Troubleshooting
 
-- If you see "Costa CLI not found", either reinstall the extension or install `costa` on your PATH and restart VS Code
+- If you see "Costa CLI not found", reinstall the extension or install `costa` on your PATH and restart VS Code
 - Status bar values show `-` until you're logged in and data is available
-- On macOS, installing to `/usr/local/bin` prompts for administrator privileges

--- a/package.json
+++ b/package.json
@@ -112,11 +112,6 @@
         "command": "costa.refreshPoints",
         "title": "Refresh Points",
         "category": "Costa Code"
-      },
-      {
-        "command": "costa.install.system",
-        "title": "Install Costa CLI to System",
-        "category": "Costa Code"
       }
     ],
     "menus": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from 'vscode'
 import { execFile } from 'node:child_process'
-import { chmodSync, copyFileSync, existsSync } from 'node:fs'
+import { chmodSync, existsSync } from 'node:fs'
 import * as path from 'node:path'
 import process from 'node:process'
 import { log } from './utils/logger'
@@ -160,11 +160,6 @@ export interface SetupComponentStatus {
 export interface SetupStatusResult {
   claude_code?: SetupComponentStatus
   codex?: SetupComponentStatus
-  system_binary?: {
-    installed?: boolean
-    version?: string
-    path?: string
-  }
 }
 
 export async function setupStatus(): Promise<SetupStatusResult> {
@@ -199,94 +194,5 @@ export async function setupCodex(): Promise<void> {
   catch (error) {
     log.error('cli.setupCodex failed:', error)
     throw error
-  }
-}
-
-interface VersionResult {
-  version?: string
-  commit?: string
-  date?: string
-}
-
-export async function getSystemBinaryInfo(): Promise<{ installed: boolean, version?: string, path: string }> {
-  const installPath = '/usr/local/bin/costa'
-
-  // Check common system locations for existing installation
-  const commonPaths = ['/usr/local/bin/costa', '/opt/homebrew/bin/costa', '/usr/bin/costa']
-  let existingPath: string | null = null
-
-  for (const p of commonPaths) {
-    if (existsSync(p)) {
-      existingPath = p
-      break
-    }
-  }
-
-  if (!existingPath) {
-    log.info('cli.getSystemBinaryInfo: system binary not found')
-    return { installed: false, path: installPath }
-  }
-
-  try {
-    const { stdout } = await new Promise<{ stdout: string, stderr: string }>((resolve, reject) => {
-      execFile(existingPath!, ['version', '--format', 'json'], { timeout: 5_000 }, (err, stdout, stderr) => {
-        if (err) {
-          reject(err)
-          return
-        }
-        resolve({ stdout: (stdout || '').toString(), stderr: (stderr || '').toString() })
-      })
-    })
-
-    const result = JSON.parse(stdout) as VersionResult
-    log.info(`cli.getSystemBinaryInfo: version=${result.version} at ${existingPath}`)
-    return { installed: true, version: result.version, path: existingPath }
-  }
-  catch (error) {
-    log.error('cli.getSystemBinaryInfo: failed to get version', error)
-    return { installed: true, path: existingPath }
-  }
-}
-
-export async function installToSystem(): Promise<void> {
-  if (!extensionContext) {
-    throw new Error('CLI context not initialized')
-  }
-
-  const bundledBin = getBundledCliPath(extensionContext)
-  if (!existsSync(bundledBin)) {
-    throw new Error('Bundled binary not found')
-  }
-
-  const systemPath = '/usr/local/bin/costa'
-
-  // On macOS, use osascript for admin elevation
-  if (process.platform === 'darwin') {
-    log.info('cli.installToSystem: using osascript for elevation on macOS')
-    return await new Promise<void>((resolve, reject) => {
-      const script = `do shell script "cp '${bundledBin}' '${systemPath}' && chmod 755 '${systemPath}'" with administrator privileges`
-      execFile('osascript', ['-e', script], { timeout: 60_000 }, (err, stdout, stderr) => {
-        if (err) {
-          const msg = (stderr || '').toString().trim()
-          log.error('cli.installToSystem: osascript failed', err)
-          reject(new Error(msg ? `Installation failed: ${msg}` : 'Installation cancelled or failed'))
-          return
-        }
-        log.info('cli.installToSystem: installation successful')
-        resolve()
-      })
-    })
-  }
-
-  // On Linux, attempt direct copy and chmod (will fail if no permissions)
-  try {
-    log.info('cli.installToSystem: attempting direct copy on Linux')
-    copyFileSync(bundledBin, systemPath)
-    chmodSync(systemPath, 0o755)
-    log.info('cli.installToSystem: installation successful')
-  }
-  catch (error) {
-    log.error('cli.installToSystem: direct copy failed', error)
-    throw new Error(`Permission denied. Please run: sudo cp "${bundledBin}" "${systemPath}" && sudo chmod 755 "${systemPath}"`)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,27 +234,6 @@ const { activate, deactivate } = defineExtension((context) => {
         window.showErrorMessage(`Codex setup failed: ${String(error)}`)
       }
     },
-    'costa.install.system': async () => {
-      try {
-        await window.withProgress(
-          {
-            location: ProgressLocation.Notification,
-            title: 'Installing costa to /usr/local/bin...',
-            cancellable: false,
-          },
-          async () => {
-            await cli.installToSystem()
-            await usageProvider.refreshAll()
-            await setupProvider.refreshAll()
-          },
-        )
-        window.showInformationMessage('Successfully installed costa to /usr/local/bin')
-      }
-      catch (error) {
-        log.error('index: install.system failed', error)
-        window.showErrorMessage(`Installation failed: ${String(error)}`)
-      }
-    },
     'costa.refreshPoints': async () => {
       log.info('index: Manually refreshing points data')
       if (isDevelopment) {

--- a/src/views/sidebar.ts
+++ b/src/views/sidebar.ts
@@ -54,9 +54,6 @@ export class SidebarProvider implements WebviewViewProvider {
           case 'setup:codex':
             await vscode.commands.executeCommand('costa.setup.codex')
             break
-          case 'install:systemCosta':
-            await vscode.commands.executeCommand('costa.install.system')
-            break
           case 'refresh':
             await this.refreshAll()
             break
@@ -85,17 +82,13 @@ export class SidebarProvider implements WebviewViewProvider {
 
   public async refreshAll() {
     try {
-      const [status, setupStatus, systemBinary] = await Promise.all([
+      const [status, setupStatus] = await Promise.all([
         cli.status().catch((err) => {
           log.error('sidebar: status failed', err)
           return undefined
         }),
         cli.setupStatus().catch((err) => {
           log.error('sidebar: setup status failed', err)
-          return undefined
-        }),
-        cli.getSystemBinaryInfo().catch((err) => {
-          log.error('sidebar: getSystemBinaryInfo failed', err)
           return undefined
         }),
       ])
@@ -107,10 +100,7 @@ export class SidebarProvider implements WebviewViewProvider {
         context_length: this.latestUsage?.context_length ?? (status as any)?.context_length ?? '-',
       }
 
-      const setup = {
-        ...setupStatus,
-        system_binary: systemBinary,
-      }
+      const setup = setupStatus
 
       this.postState({ loggedIn, usage, setup })
     }
@@ -372,19 +362,6 @@ function render(state) {
           </p>
           <button id="setup-codex">Set up Codex</button>
         </div>
-
-        \${isUnix ? \`
-        <div class="card">
-          <h4>Costa CLI</h4>
-          <p>
-            <span class="status-badge \${setup.system_binary?.installed ? 'status-configured' : 'status-not-configured'}">
-              \${setup.system_binary?.installed ? '✓ Installed' : '⚠ Not Installed'}
-            </span>
-          </p>
-          \${setup.system_binary?.version ? \`<p>Version: \${setup.system_binary.version}</p>\` : ''}
-          <button id="install-system-costa">Install to /usr/local/bin</button>
-        </div>
-        \` : ''}
       </div>
     \`;
 
@@ -396,11 +373,6 @@ function render(state) {
     const setupCodexBtn = document.getElementById('setup-codex');
     if (setupCodexBtn) {
       setupCodexBtn.onclick = () => vscode.postMessage({ type: 'setup:codex' });
-    }
-
-    const installBtn = document.getElementById('install-system-costa');
-    if (installBtn) {
-      installBtn.onclick = () => vscode.postMessage({ type: 'install:systemCosta' });
     }
   }
 }


### PR DESCRIPTION
Remove the "Install CLI to System" functionality that was not working consistently (for now).

This includes:
- Removal of costa.install.system command
- Removal of CLI installation UI from Setup panel
- Removal of installToSystem() and getSystemBinaryInfo() functions
- Cleanup of related documentation in README